### PR TITLE
Custom CircleCI release job now clone the GH repo.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
             python3 -m pip install pytest
             python3 -m pip install --upgrade build
             python3 -m build
-            pip install dist/smalltools_st-0.0.8-py3-none-any.whl
+            pip install dist/smalltools_st-0.0.9-py3-none-any.whl
       - run:
           name: Run tests
           command: | # Run test suite
@@ -65,6 +65,7 @@ jobs:
             fingerprints:
               - "a2:dc:ef:ef:f7:56:9f:af:ad:86:68:83:f1:0e:e7:9d"
       - gh/setup
+      - gh/clone
       - run:
           name: "Creating a GitHub Release"
           command: |
@@ -72,7 +73,7 @@ jobs:
             set -- "$@" --notes-file "./CHANGELOG.md"
             set -- "$@" --title "Added: Full automation with CircleCI its here!"
             set -- "$@" --repo "$(git config --get remote.origin.url)"
-            gh release create "0.0.8" "$@"
+            gh release create "0.0.9" "$@"
 workflows:
   build_test_publish:
     jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.0.9] - 2022-03-28
+
+### Fixed
+
+- Custom CircleCI release job now clone the GH repo.
+
 ## [0.0.8] - 2022-03-28
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "smalltools_st"
-version = "0.0.8"
+version = "0.0.9"
 authors = [
   { name="Armando Ezequiel Puerta", email="armando.ezequiel.puerta@gmail.com" },
 ]


### PR DESCRIPTION
v0.0.9: Custom CircleCI release job now clone the GH repo.